### PR TITLE
Improve logging report

### DIFF
--- a/changes1/usr/etc/fluent-bit/fluent-bit.conf
+++ b/changes1/usr/etc/fluent-bit/fluent-bit.conf
@@ -60,7 +60,7 @@
 [INPUT]
     Name    exec
     Tag     logreport
-    Command printf "{\"system_errors\":`journalctl -t compose -p 3..3 | wc -l`,\"system_warning\":`journalctl -t compose -p 4..4 | wc -l`}\n"
+    Command printf "{\"system_errors\":`journalctl -o cat -t compose -p 3..3 | wc -l`,\"system_warning\":`journalctl -o cat -t compose -p 4..4 | wc -l`}\n"
     Parser  json
     interval_sec 30
 


### PR DESCRIPTION
with -o cat journalctl shows messages in very
short form, without any date/time or source server names. 
So this removes prolog and epilog from the error and warning count